### PR TITLE
Fix link to official documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Allows Behat to load features from Jira issues
 
 ## Documentation
 
-[Official documentation](http://extensions.behat.org/jira/index.html)
+[Official documentation](http://extensions.behat.org/jira-extension/)
 
 ## Source
 


### PR DESCRIPTION
I noticed that the link was broken, but that the documentation was indeed there @ behat.org.
