### PR TITLE
NEW: Import .feature files into an associated Jira Ticket

### DIFF
--- a/src/VIPSoft/JiraExtension/Extension.php
+++ b/src/VIPSoft/JiraExtension/Extension.php
@@ -52,6 +52,12 @@ class Extension implements ExtensionInterface
         if (isset($config['feature_field'])) {
             $container->setParameter('behat.jira.feature_field', $config['feature_field']);
         }
+        if (isset($config['push_issue'])) {
+            $container->setParameter('behat.jira.push_issue', $config['push_issue']);
+        }
+        if (isset($config['tag_pattern'])){
+            $container->setParameter('behat.jira.tag_pattern', $config['tag_pattern']);
+        }
         if (isset($config['cache_directory'])) {
             $directory = realpath(rtrim($config['cache_directory'], '/'));
             $container->setParameter('behat.jira.cache_directory', $directory);
@@ -77,6 +83,9 @@ class Extension implements ExtensionInterface
                 scalarNode('jql')->
                     defaultNull()->
                 end()->
+                scalarNode('push_issue')->
+                    defaultFalse()->
+                end()->
                 scalarNode('comment_on_pass')->
                     defaultFalse()->
                 end()->
@@ -91,6 +100,9 @@ class Extension implements ExtensionInterface
                 end()->
                 scalarNode('cache_directory')->
                     defaultNull()->
+                end()->
+                scalarNode('tag_pattern')->
+                    defaultValue('/jira:(.*)/')->
                 end()->
             end()->
         end();

--- a/src/VIPSoft/JiraExtension/services/core.xml
+++ b/src/VIPSoft/JiraExtension/services/core.xml
@@ -46,12 +46,15 @@
             <argument type="string">%behat.jira.user%</argument>
             <argument type="string">%behat.jira.password%</argument>
             <argument type="string">%behat.jira.jql%</argument>
+            <argument type="string">%behat.jira.feature_field%</argument>
         </service>
 
         <service id="behat.jira.listener.hook" class="%behat.jira.listener.hook.class%">
             <argument type="string">%behat.jira.comment_on_pass%</argument>
             <argument type="string">%behat.jira.comment_on_fail%</argument>
             <argument type="string">%behat.jira.reopen_on_fail%</argument>
+            <argument type="string">%behat.jira.push_issue%</argument>
+            <argument type="string">%behat.jira.tag_pattern%</argument>
             <argument type="service" id="behat.jira.service.jira" />
             <tag name="behat.event_subscriber" priority="0" />
         </service>


### PR DESCRIPTION
**What it does?**: This PR allows you to tag your scenarios with a specific Jira Ticket and after the test suite is completed, it pushes the resulting scenario text into specified Jira ticket ("feature_field"). 

**Reason for new feature:** This means that the feature files can be kept into source control, and still have a method for Buisness Users to read with direct access to the source code. 

**Problems Still to overcome:** Not entirely sure how we will be able to hide the complications of branching to business users. With most development its key to make feature branches which last 1-2weeks, and it will be hard to keep track within this. If you have any suggestions I am open.

**How to configure it:** It installs as normal but it requires an extra config in the .yml file. Here is my sample .yml file:

```
VIPSoft\JiraExtension\Extension:
      host: <jira-host>
      user: ~
      password: ~
      jql: "summary ~ 'Feature'"
      push_issue: true
      feature_field: "customfield_11700"
      comment_on_pass: false
      comment_on_fail: false
      reopen_on_fail: false
      cache_directory: /tmp/behat-jira
```
